### PR TITLE
Novos Modulos para TNT

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
-# Geartrack
+# Geartrack 1.0 (No further updates to this version)
 
 [![Join the chat at https://gitter.im/hdnpt/geartrack-website](https://badges.gitter.im/hdnpt/geartrack-website.svg)](https://gitter.im/hdnpt/geartrack-website?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 >Online version: [https://geartrack.pt](https://geartrack.pt)
 
-This is an Express.js app
+**Geartrack 2.0 is under development, this version will no longer be mantained. Use the online version which will always be updated :)**
+
+This is an Express.js app.
 
 ### Screenshot
 ![Screen](http://i.imgur.com/wUhzJO3.png)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is an Express.js app.
 ### Requirements
 - Node
 - Environment variables:
-    - (optional) **GEARTRACK_PROXYS**: `ip,ip,ip`  - Some trackers may block your machine ip, use different proxys to get the data.
+    - (optional) **GEARTRACK_PROXYS**: `ip,ip,ip`  - Some trackers may block your machine ip, use different proxies to get the data.
     - (optional) **GEARTRACK_BUGSNAG**: `apikey` - When an exception occurs on production you are notified by email.
 
 ### Instructions
@@ -31,7 +31,7 @@ To build and run locally:
 - `docker run -d -p 80:3000 geartrack-website`
 
 Using the public image on docker hub:
-- `docker run -d -p 80:3000 hdnpt/geartrack-website` - the latest image will be downloaded and the geartrack will be availabe at `http://localhost` (to stop use `docker stop [containerid]`)
+- `docker run -d -p 80:3000 hdnpt/geartrack-website` - the latest image will be downloaded and the geartrack will be available at `http://localhost` (to stop use `docker stop [containerid]`)
 
 Passing environment variables:
 - `docker run -d -p 80:3000 -e "GEARTRACK_BUGSNAG=apikey" hdnpt/geartrack-website`


### PR DESCRIPTION
Possivelmente não tem, pois tentei e não vi info.
Penso que falta adicionarem os módulos para o tracking da TNT / FEDEX. 
Assim conseguiremos seguir as encomendas deles também.